### PR TITLE
test: guard against worker-dispatch request header loss (node:http)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "deno_cache_dir"
 version = "0.39.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "async-trait",
  "base32",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "deno_config"
 version = "0.97.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "boxed_error",
  "capacity_builder",
@@ -2436,12 +2436,12 @@ dependencies = [
 [[package]]
 name = "deno_console"
 version = "0.222.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 
 [[package]]
 name = "deno_core"
 version = "0.400.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "anyhow",
  "az",
@@ -2530,7 +2530,7 @@ dependencies = [
 [[package]]
 name = "deno_crypto_provider"
 version = "0.41.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "aws-lc-sys 0.39.1",
 ]
@@ -2538,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "deno_dotenv"
 version = "0.16.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "deno_path_util",
  "sys_traits",
@@ -2618,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "deno_features"
 version = "0.44.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "deno_core",
  "serde",
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "deno_fetch"
 version = "0.271.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2667,7 +2667,7 @@ dependencies = [
 [[package]]
 name = "deno_fs"
 version = "0.157.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "async-trait",
  "base32",
@@ -2785,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "deno_inspector_server"
 version = "0.21.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -2803,7 +2803,7 @@ dependencies = [
 [[package]]
 name = "deno_io"
 version = "0.157.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -2828,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "deno_lockfile"
 version = "0.49.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "async-trait",
  "deno_semver",
@@ -2840,7 +2840,7 @@ dependencies = [
 [[package]]
 name = "deno_maybe_sync"
 version = "0.34.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "dashmap",
 ]
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "deno_net"
 version = "0.239.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "deno_node_crypto"
 version = "0.17.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "aead-gcm-stream",
  "aes",
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "deno_node_sqlite"
 version = "0.17.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -2977,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "deno_npm"
 version = "0.59.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "async-trait",
  "capacity_builder",
@@ -2998,7 +2998,7 @@ dependencies = [
 [[package]]
 name = "deno_npm_cache"
 version = "0.66.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -3032,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "deno_npm_installer"
 version = "0.42.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -3074,7 +3074,7 @@ dependencies = [
 [[package]]
 name = "deno_npmrc"
 version = "0.8.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "log",
  "monch",
@@ -3087,7 +3087,7 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.276.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "indexmap 2.14.0",
  "proc-macro2",
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "deno_os"
 version = "0.64.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "deno_otel_attrs"
 version = "0.1.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "opentelemetry",
 ]
@@ -3131,7 +3131,7 @@ dependencies = [
 [[package]]
 name = "deno_package_json"
 version = "0.49.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "boxed_error",
  "capacity_builder",
@@ -3163,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "deno_permissions"
 version = "0.106.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "capacity_builder",
  "chrono",
@@ -3193,7 +3193,7 @@ dependencies = [
 [[package]]
 name = "deno_process"
 version = "0.62.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "deno_resolver"
 version = "0.78.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "deno_signals"
 version = "0.38.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "deno_error",
  "libc",
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "deno_subprocess_windows"
 version = "0.42.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "fastrand",
  "futures-channel",
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "deno_telemetry"
 version = "0.69.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -3354,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "deno_tls"
 version = "0.234.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -4183,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "ext_node"
 version = "0.1.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "base64 0.22.1",
  "boxed_error",
@@ -6664,7 +6664,7 @@ dependencies = [
 [[package]]
 name = "node_resolver"
 version = "0.85.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 [[package]]
 name = "node_shim"
 version = "0.22.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "exec",
  "serde_json",
@@ -8745,7 +8745,7 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.309.0"
-source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#83429086cdd23151d31596a9010496674f8675d1"
+source = "git+https://github.com/p-hoffmann/deno?branch=trex-v2.7.14#105c6663b3ef75c33047295341a23ae7aa842c18"
 dependencies = [
  "deno_error",
  "num-bigint",

--- a/crates/base/test_cases/commonjs-express/index.js
+++ b/crates/base/test_cases/commonjs-express/index.js
@@ -8,6 +8,16 @@ app.get("/commonjs-express", (_, res) => {
   res.send("meow");
 });
 
+// Regression guard: an embedder server like express re-parents the request via
+// `Object.setPrototypeOf(req, app.request)`. After the Deno 2.7.14 node:http
+// split that dropped the server IncomingMessage's header getters, leaving
+// `req.headers` empty for the trex edge-runtime worker-dispatch path (all
+// request headers, incl. authorization, were lost). Echo the header back so the
+// integration test can assert it survives.
+app.get("/commonjs-express/echo-auth", (req, res) => {
+  res.send(req.headers.authorization ?? "MISSING");
+});
+
 app.listen(port, () => {
   console.log(`app listening on port ${port}`);
 });

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -3257,6 +3257,41 @@ async fn test_commonjs_express() {
   );
 }
 
+// Regression guard for the Deno 2.7.14 node:http rewrite. An embedder server
+// (express) re-parents the incoming request via `Object.setPrototypeOf`, which
+// after the node:http split dropped the server IncomingMessage's header getters
+// and left `req.headers` empty for the trex worker-dispatch path -- losing ALL
+// request headers, including `authorization`. This sends a request with an
+// Authorization header and asserts it reaches the express handler unchanged.
+#[tokio::test]
+#[serial]
+async fn test_commonjs_express_forwards_request_headers() {
+  ensure_npm_package_installed("./test_cases/commonjs-express").await;
+  integration_test!(
+    "./test_cases/main",
+    NON_SECURE_PORT,
+    "commonjs-express/echo-auth",
+    None,
+    Some(
+      reqwest::Client::new()
+        .get(format!(
+          "http://localhost:{NON_SECURE_PORT}/commonjs-express/echo-auth"
+        ))
+        .header("authorization", "Bearer trex-regression-token"),
+    ),
+    None,
+    (|resp| async {
+      let resp = resp.unwrap();
+      assert_eq!(resp.status().as_u16(), 200);
+      assert_eq!(
+        resp.text().await.unwrap().as_str(),
+        "Bearer trex-regression-token",
+      );
+    }),
+    TerminationToken::new()
+  );
+}
+
 #[tokio::test]
 #[serial]
 async fn test_commonjs_hono() {


### PR DESCRIPTION
Adds an integration test that catches the class of bug where the trex edge-runtime worker dispatch drops **all** request headers (including `Authorization`) before they reach a user-worker handler.

## Why
Deno 2.7.14 rewrote/split `node:http` into separate `IncomingMessage` classes. The trex serve handler builds an `IncomingMessageForServer` that stores headers under its own `kRawHeaders` symbol via **prototype getters**. When an embedder server (e.g. `express` via `app.listen()`) re-parents the request with `Object.setPrototypeOf(req, app.request)`, those getters leave the prototype chain, and `node:http`'s `IncomingMessage` getter then reads `this.rawHeaders`/`kHeadersCount` (absent on the instance) — so `req.headers` comes back **empty**. (Fix: materialize `headers`/`rawHeaders` as own data properties in the deno fork '`_http_server.ts`'.)

This regression only manifests through the worker-dispatch path (not standalone `node:http`/`express`), so a plain deno test would not catch it — hence an integration test here.

## What
- `crates/base/test_cases/commonjs-express/index.js`: add a `/commonjs-express/echo-auth` route that echoes `req.headers.authorization`.
- `crates/base/tests/integration_tests.rs`: `test_commonjs_express_forwards_request_headers` sends `Authorization: Bearer …` through the express worker and asserts it arrives unchanged.

Fails on the broken stack (empty `req.headers`), passes once headers survive re-parenting.